### PR TITLE
Convert site to StockAlert theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Klipta Site
+# StockAlert Site
 
-This is the official site for **Klipta**, built with React + TailwindCSS via Vite.
+This is the official site for **StockAlert**, built with React and TailwindCSS via Vite.
 
 ## 🚀 Deploy on Vercel
 

--- a/src/StockAlertSite.jsx
+++ b/src/StockAlertSite.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from "react";
 
-export default function KliptaSite() {
+export default function StockAlertSite() {
   const [menuOpen, setMenuOpen] = useState(false);
   const [showTestimonials, setShowTestimonials] = useState(false);
 
@@ -20,13 +20,13 @@ export default function KliptaSite() {
       {/* Navbar */}
       <header className="fixed top-0 left-0 w-full bg-white text-[#1E2A38] border-b border-gray-200 z-50 shadow-sm">
         <div className="max-w-7xl mx-auto px-4 flex justify-between items-center h-16">
-          <div className="text-2xl font-extrabold tracking-wide text-[#00C2A8]">Klipta</div>
+          <div className="text-2xl font-extrabold tracking-wide text-[#00C2A8]">StockAlert</div>
           <nav className="hidden md:flex items-center space-x-6 text-sm font-medium">
-            <a href="#services" className="hover:text-[#00C2A8]">Services</a>
-            <a href="#pricing" className="hover:text-[#00C2A8]">Pricing</a>
-            <a href="#testimonials" className="hover:text-[#00C2A8]">Testimonials</a>
-            <a href="#contact" className="hover:text-[#00C2A8]">Contact</a>
-            <a href="#contact" className="ml-4 bg-[#00C2A8] text-white px-4 py-2 rounded-full hover:bg-[#009f8a] transition">Book a Call</a>
+            <a href="#services" className="hover:text-[#00C2A8]">Funcionalidades</a>
+            <a href="#pricing" className="hover:text-[#00C2A8]">Preços</a>
+            <a href="#testimonials" className="hover:text-[#00C2A8]">Depoimentos</a>
+            <a href="#contact" className="hover:text-[#00C2A8]">Contacto</a>
+            <a href="#contact" className="ml-4 bg-[#00C2A8] text-white px-4 py-2 rounded-full hover:bg-[#009f8a] transition">Agendar Demo</a>
           </nav>
           <button onClick={() => setMenuOpen(!menuOpen)} className="md:hidden focus:outline-none">
             <svg className="w-6 h-6 text-[#1E2A38]" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
@@ -36,10 +36,10 @@ export default function KliptaSite() {
         </div>
         {menuOpen && (
           <div className="md:hidden bg-white px-4 py-4 space-y-2 text-sm font-medium border-t border-gray-200">
-            <a href="#services" className="block text-[#1E2A38] hover:text-[#00C2A8]">Services</a>
-            <a href="#pricing" className="block text-[#1E2A38] hover:text-[#00C2A8]">Pricing</a>
-            <a href="#testimonials" className="block text-[#1E2A38] hover:text-[#00C2A8]">Testimonials</a>
-            <a href="#contact" className="block text-white bg-[#00C2A8] px-4 py-2 rounded-full text-center">Book a Call</a>
+            <a href="#services" className="block text-[#1E2A38] hover:text-[#00C2A8]">Funcionalidades</a>
+            <a href="#pricing" className="block text-[#1E2A38] hover:text-[#00C2A8]">Preços</a>
+            <a href="#testimonials" className="block text-[#1E2A38] hover:text-[#00C2A8]">Depoimentos</a>
+            <a href="#contact" className="block text-white bg-[#00C2A8] px-4 py-2 rounded-full text-center">Agendar Demo</a>
           </div>
         )}
       </header>
@@ -47,11 +47,11 @@ export default function KliptaSite() {
       {/* Hero Section */}
       <section className="bg-gradient-to-br from-[#00C2A8] to-[#007D74] text-white text-center py-40 px-4">
         <div className="max-w-4xl mx-auto">
-          <h1 className="text-5xl font-extrabold mb-6 leading-tight">Your data. Automated.</h1>
-          <p className="text-xl mb-8 opacity-90">Custom Power BI dashboards that eliminate manual work.</p>
+          <h1 className="text-5xl font-extrabold mb-6 leading-tight">Alertas de stock em tempo real.</h1>
+          <p className="text-xl mb-8 opacity-90">Receba notificações sempre que o inventário estiver abaixo do nível definido.</p>
           <div className="flex justify-center gap-4 flex-wrap">
-            <a href="#pricing" className="bg-white text-[#00C2A8] font-semibold py-3 px-8 rounded-full shadow-md hover:bg-gray-100 transition">See Plans</a>
-            <a href="#contact" className="border border-white font-semibold py-3 px-8 rounded-full hover:bg-white hover:text-[#00C2A8] transition">Book a Free Call</a>
+            <a href="#pricing" className="bg-white text-[#00C2A8] font-semibold py-3 px-8 rounded-full shadow-md hover:bg-gray-100 transition">Ver Planos</a>
+            <a href="#contact" className="border border-white font-semibold py-3 px-8 rounded-full hover:bg-white hover:text-[#00C2A8] transition">Marcar Demonstração</a>
           </div>
         </div>
       </section>
@@ -59,13 +59,13 @@ export default function KliptaSite() {
       {/* Placeholder for rest of site */}
       <section className="text-center py-24 px-6 bg-white">
         <div className="max-w-3xl mx-auto">
-          <h2 className="text-3xl font-bold text-[#1E2A38] mb-6">Site in progress</h2>
-          <p className="text-lg text-gray-600">This is your starting structure for Klipta. Add more sections like Services, Pricing, and Testimonials here.</p>
+          <h2 className="text-3xl font-bold text-[#1E2A38] mb-6">Site em desenvolvimento</h2>
+          <p className="text-lg text-gray-600">Esta é a estrutura inicial do StockAlert. Adicione seções como Funcionalidades, Preços e Depoimentos aqui.</p>
         </div>
       </section>
 
       <footer className="bg-[#1E2A38] text-white text-center py-6 text-sm">
-        <p>&copy; 2025 Klipta. All rights reserved.</p>
+        <p>&copy; 2025 StockAlert. Todos os direitos reservados.</p>
         <p className="mt-2 text-gray-300 text-xs">🔒 All shared data is 100% confidential and securely handled.</p>
       </footer>
     </div>

--- a/src/index.html
+++ b/src/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Klipta</title>
+    <title>StockAlert</title>
   </head>
   <body>
     <div id="root"></div>

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,10 +1,10 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
 import './index.css'
-import KliptaSite from './KliptaSite'
+import StockAlertSite from './StockAlertSite'
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
-    <KliptaSite />
+    <StockAlertSite />
   </React.StrictMode>
 )


### PR DESCRIPTION
## Summary
- rename main component to `StockAlertSite`
- replace all branding and text with StockAlert messaging
- update README and HTML title

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684d30c969ac83329a21c47b4420073f